### PR TITLE
Improves the profile picture Layout on resizing

### DIFF
--- a/_sass/profile.scss
+++ b/_sass/profile.scss
@@ -5,8 +5,14 @@
     background-position: center;
 
     text-align: center;
-    height: 320px;
-    margin-bottom: 50px;
+    min-height: 60vh;
+    margin-bottom: 00px;
+
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: space-between;
+
     h1 {
         font-size: 50px;
         font-weight: 700;
@@ -25,6 +31,5 @@
     
     .profile-picture {
         margin-bottom: 30px;
-        height: 200px;
     }
 }

--- a/_sass/profile.scss
+++ b/_sass/profile.scss
@@ -20,13 +20,13 @@
     }
     
     img {
+        object-fit: cover;
         border-radius: 50%;
-        max-width: 100%;
-        max-height: 100%;
-        margin-left: auto;
-        margin-right: auto;
+        width: 200px ;
+        height: 200px;
         display: inline;        
         padding: 20px;
+        margin: 20px;
     }
     
     .profile-picture {


### PR DESCRIPTION
This PR improves the current bug of profile image resizing issue due to different screen resolution. Now the profile pictures at the top, won't overflow when the screen is too narrow, or there's too many pictures!
Fixes #12 

- [x] My Pod Leader knows I'm working on this Pull Request
- [x] I've explained what the Pull Request is adding.
- [x] I've explained why this is important.

