### PR TITLE
Closes #56: separates location of markers in map

### DIFF
--- a/assets/js/maps.js
+++ b/assets/js/maps.js
@@ -35,8 +35,8 @@ const fellows = [
         role: 'Fellow',
     },
     {
-        lat: 19.075983,
-        long: 72.877655,
+        lat: 18.9894,
+        long: 73.1175,
         pic: 'siddhi.jpg',
         name: 'Siddhi Bhanushali',
         location: 'Mumbai, India',
@@ -65,8 +65,8 @@ const fellows = [
         role: 'Fellow',
     },
     {
-      lat: 19.075983,
-        long: 72.877655,
+        lat: 19.2183,
+        long: 72.9781,
         pic: 'bhavneet.jpg',
         name: 'Bhavneet Kaur',
         location: 'Mumbai, India',
@@ -85,8 +85,8 @@ const fellows = [
         role: 'Fellow',
     },
     {
-        lat: 28.535517,
-        long: 77.391029,
+        lat: 28.4610,
+        long: 77.4969,
         pic: 'akanksha.jpg',
         name: 'Akanksha Kushwaha',
         location: 'Noida, India',


### PR DESCRIPTION
## What I have done?
- The problem #56 was due to overlapping of markers at same location, which was removed by separating the markers by some small number of latitude and longitude position so, the markers won't overlap.

- [x] My Pod Leader knows I'm working on this Pull Request
- [x] I've explained what the Pull Request is adding.
- [x] I've explained why this is important.

